### PR TITLE
Fix devenv configuration file.

### DIFF
--- a/.devenv
+++ b/.devenv
@@ -3,3 +3,12 @@ DISTRIBUTION="ubuntu"
 RELEASE="xenial"
 ARCH="amd64"
 HOST="local.$NAME.coop"
+
+# Mount project vars
+# PROJECT_NAME=
+# PROJECT_PATH=
+# PROJECT_PATH=
+
+# User Management
+# DEVENV_USER=
+# DEVENV_GROUP=


### PR DESCRIPTION
We don't use, in this project provisioning context, mount folder project or need a new user/group that replaces the original one.

For this reason and this PRs [#12](https://github.com/coopdevs/devenv/pull/12) and [#13](https://github.com/coopdevs/devenv/pull/13) that do the project and user parts of `devenv` script optionals, we can comment unused project and user/group vars.