### PR TITLE
Install Logstash

### DIFF
--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -12,6 +12,8 @@
   - role: elasticsearch
   - role: kibana
   - role: metricbeat
+  - role: geerlingguy.logstash
+
   - role: geerlingguy.htpasswd
     vars:
       htpasswd_credentials:

--- a/requirements.yml
+++ b/requirements.yml
@@ -4,5 +4,8 @@
 - src: geerlingguy.htpasswd
   version: 1.0.0
 
+- src: geerlingguy.logstash
+  version: 3.0.1
+
 - src: jdauphant.nginx
   version: v2.18.1


### PR DESCRIPTION
This first iteration works with Elasticsearch, Kibana, and a *filebeat* or *metricbeat* that send the log information directly to Elastic.
The ELK stack includes a log processor that parse and filter the information. In this case is [Logstash](https://www.elastic.co/products/logstash). The *L* in the E*L*K stack.

With this PR we want install Logstash in the server and configure the beats to send the info to Logstash and it processes the info and saves it in Elastic.

**TODO**

- [X] Install Logstash with the `site.yml` playbook.
- [ ] Configure beats to send logs to Logstash.
- [ ] Configure Logstash to send the processed data to Elastic. 
